### PR TITLE
Support floating value metrics.

### DIFF
--- a/src/cached.rs
+++ b/src/cached.rs
@@ -1,0 +1,29 @@
+use chrono::{DateTime, Utc};
+use std::time::{Duration, Instant};
+
+pub struct CachedDate {
+    time: DateTime<Utc>,
+    clock: Instant,
+}
+
+impl CachedDate {
+    pub fn new() -> Self {
+        Self {
+            time: Utc::now(),
+            clock: Instant::now(),
+        }
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.clock.elapsed()
+    }
+
+    pub fn reset(&mut self) {
+        self.time = Utc::now();
+        self.clock = Instant::now();
+    }
+
+    pub fn time(&self) -> DateTime<Utc> {
+        self.time
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::cached::CachedDate;
 use crate::generated::{
     google_api,
     google_monitoring_v3::{
@@ -22,7 +23,7 @@ pub struct TypedResource {
     pub labels: std::collections::HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricKind {
     Cumulative,
     Gauge,
@@ -36,43 +37,8 @@ pub enum ValueType {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Point {
-    pub interval: Interval,
-    pub value: PointValue,
-}
-
-impl Point {
-    fn incr_by(&mut self, point_value: PointValue) {
-        self.value.value += point_value.value;
-    }
-
-    fn replace(&mut self, point_value: PointValue) {
-        self.value = point_value;
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Interval {
-    pub start_time: Option<chrono::DateTime<chrono::Utc>>,
-    pub end_time: chrono::DateTime<chrono::Utc>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct PointValue {
-    value: f64,
-}
-
-impl PointValue {
-    pub fn new(value: f64) -> Self {
-        Self { value }
-    }
-
-    pub fn as_i64(self) -> i64 {
-        self.value as i64
-    }
-
-    pub fn as_f64(self) -> f64 {
-        self.value
-    }
+    pub value: f64,
+    pub created: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Clone)]
@@ -84,22 +50,29 @@ pub struct TimeSeries {
     pub points: Point,
 }
 
-fn to_timestamp(datetime: &chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
+fn to_timestamp(datetime: chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
     prost_types::Timestamp {
         seconds: datetime.timestamp(),
         nanos: datetime.timestamp_nanos() as i32,
     }
 }
 
+/// According to GCP, a metric start time can't be more than 25 hours in the past.
+const DURATION_25_HOURS: Duration = Duration::from_secs(25 * 3_600);
+
 impl TimeSeries {
-    fn as_wire_record(self) -> google_monitoring_v3::TimeSeries {
-        let start_time = if let Some(start_time) = self.points.interval.start_time.as_ref() {
-            Some(to_timestamp(start_time))
+    fn as_wire_record(self, cached_date: &mut CachedDate) -> google_monitoring_v3::TimeSeries {
+        if cached_date.elapsed() >= DURATION_25_HOURS {
+            cached_date.reset();
+        }
+
+        let end_time = to_timestamp(self.points.created);
+        let start_time = if self.metric_kind == MetricKind::Gauge {
+            end_time.clone()
         } else {
-            None
+            to_timestamp(cached_date.time())
         };
 
-        let end_time = Some(to_timestamp(&self.points.interval.end_time));
         let metric_kind = match self.metric_kind {
             MetricKind::Cumulative => {
                 crate::generated::google_api::metric_descriptor::MetricKind::Cumulative
@@ -119,8 +92,8 @@ impl TimeSeries {
         };
 
         let value = match self.value_type {
-            ValueType::Int64 => typed_value::Value::Int64Value(self.points.value.as_i64()),
-            ValueType::Double => typed_value::Value::DoubleValue(self.points.value.as_f64()),
+            ValueType::Int64 => typed_value::Value::Int64Value(self.points.value as i64),
+            ValueType::Double => typed_value::Value::DoubleValue(self.points.value),
         };
 
         google_monitoring_v3::TimeSeries {
@@ -141,8 +114,8 @@ impl TimeSeries {
 
             points: vec![google_monitoring_v3::Point {
                 interval: Some(google_monitoring_v3::TimeInterval {
-                    end_time,
-                    start_time,
+                    end_time: Some(end_time),
+                    start_time: Some(start_time),
                 }),
 
                 value: Some(google_monitoring_v3::TypedValue { value: Some(value) }),
@@ -223,23 +196,18 @@ impl Client {
         Ok(Self { channel })
     }
 
-    pub async fn create_time_series(
+    async fn create_time_series(
         &self,
         project_id: &str,
         options: &Options,
-        series: Vec<TimeSeries>,
+        time_series: Vec<google_monitoring_v3::TimeSeries>,
     ) -> crate::Result<()> {
-        if series.len() > 200 {
+        if time_series.len() > 200 {
             return Err(Error::InvalidArgument(format!(
                 "Time series list is greater than 200, got {}",
-                series.len()
+                time_series.len()
             )));
         }
-
-        let time_series = series
-            .into_iter()
-            .map(|s| s.as_wire_record())
-            .collect::<Vec<google_monitoring_v3::TimeSeries>>();
 
         let req = CreateTimeSeriesRequest {
             name: format!("projects/{}", project_id),
@@ -267,6 +235,7 @@ impl Client {
         let mut total_metrics = 0usize;
         let mut successes = 0usize;
         let mut failures = 0usize;
+        let mut cached_date = CachedDate::new();
         let started = Instant::now();
 
         while let Some(series) = stream.next().await {
@@ -275,10 +244,10 @@ impl Client {
                 .entry(series.metric.r#type.clone())
                 .and_modify(|cur| match cur.metric_kind {
                     MetricKind::Cumulative => {
-                        cur.points.incr_by(series.points.value);
+                        cur.points.value += series.points.value;
                     }
                     MetricKind::Gauge => {
-                        cur.points.replace(series.points.value);
+                        cur.points.value = series.points.value;
                     }
                 })
                 .or_insert(series);
@@ -295,7 +264,10 @@ impl Client {
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
 
-            let series = buffer.drain().map(|t| t.1).collect::<Vec<_>>();
+            let series = buffer
+                .drain()
+                .map(|t| t.1.as_wire_record(&mut cached_date))
+                .collect::<Vec<_>>();
 
             let mut attempts = 1usize;
             loop {

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,20 +100,22 @@ impl TimeSeries {
         };
 
         let end_time = Some(to_timestamp(&self.points.interval.end_time));
-        let (metric_kind, unit) = match self.metric_kind {
-            MetricKind::Cumulative => (
-                crate::generated::google_api::metric_descriptor::MetricKind::Cumulative,
-                "INT64".to_string(),
-            ),
-            MetricKind::Gauge => (
-                crate::generated::google_api::metric_descriptor::MetricKind::Gauge,
-                "DOUBLE".to_string(),
-            ),
+        let metric_kind = match self.metric_kind {
+            MetricKind::Cumulative => {
+                crate::generated::google_api::metric_descriptor::MetricKind::Cumulative
+            }
+            MetricKind::Gauge => crate::generated::google_api::metric_descriptor::MetricKind::Gauge,
         };
 
-        let value_type = match self.value_type {
-            ValueType::Int64 => crate::generated::google_api::metric_descriptor::ValueType::Int64,
-            ValueType::Double => crate::generated::google_api::metric_descriptor::ValueType::Double,
+        let (value_type, unit) = match self.value_type {
+            ValueType::Int64 => (
+                crate::generated::google_api::metric_descriptor::ValueType::Int64,
+                "INT64".to_string(),
+            ),
+            ValueType::Double => (
+                crate::generated::google_api::metric_descriptor::ValueType::Double,
+                "DOUBLE".to_string(),
+            ),
         };
 
         let value = match self.value_type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate tracing;
+pub(crate) mod cached;
 mod client;
 pub(crate) mod generated;
 


### PR DESCRIPTION
<img width="673" alt="floating_metric" src="https://user-images.githubusercontent.com/144545/203639861-3c44c42c-3544-421f-9d44-756565e5a8ba.png">

Note that existing metrics can't have their value type changed. Doing so will lead to that error:
```
 ERROR stackdriver_metrics::client > Error when sending time_series: Unmapped gRPC error: status: InvalidArgument, message: "One or more TimeSeries could not be written: Value type for metric custom.googleapis.com/testing/metrics/reece_value must be DOUBLE, but is INT64."
```